### PR TITLE
Terraform 0.12.13 upgrade changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This module will create a "simple" (as opposed to a "global") table, with some s
 
 ```hcl
 module "example_team_dynamodb" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=2.0"
 
   team_name = "example-team"
   hash_key  = "example-hash"

--- a/main.tf
+++ b/main.tf
@@ -1,43 +1,49 @@
 provider "aws" {
   alias  = "custom"
-  region = "${var.aws_region}"
+  region = var.aws_region
 }
 
-data "aws_caller_identity" "current" {}
-data "aws_region" "current" {}
+data "aws_caller_identity" "current" {
+}
+
+data "aws_region" "current" {
+}
 
 resource "random_id" "id" {
   byte_length = 8
 }
 
 resource "aws_dynamodb_table" "default" {
-  provider       = "aws.custom"
+  provider       = aws.custom
   name           = "cp-${random_id.id.hex}"
-  read_capacity  = "${var.autoscale_min_read_capacity}"
-  write_capacity = "${var.autoscale_min_write_capacity}"
-  hash_key       = "${var.hash_key}"
-  range_key      = "${var.range_key}"
+  read_capacity  = var.autoscale_min_read_capacity
+  write_capacity = var.autoscale_min_write_capacity
+  hash_key       = var.hash_key
+  range_key      = var.range_key
 
   attribute {
-    name = "${var.hash_key}"
-    type = "${var.hash_key_type}"
+    name = var.hash_key
+    type = var.hash_key_type
   }
 
   attribute {
-    name = "${var.range_key}"
-    type = "${var.range_key_type}"
+    name = var.range_key
+    type = var.range_key_type
   }
 
   server_side_encryption {
-    enabled = "${var.enable_encryption}"
+    enabled = var.enable_encryption
   }
 
   lifecycle {
-    ignore_changes = ["read_capacity", "write_capacity"]
+    ignore_changes = [
+      read_capacity,
+      write_capacity,
+    ]
   }
 
   ttl {
-    attribute_name = "${var.ttl_attribute}"
+    attribute_name = var.ttl_attribute
     enabled        = "true"
   }
 
@@ -45,30 +51,30 @@ resource "aws_dynamodb_table" "default" {
     enabled = "true"
   }
 
-  tags {
-    business-unit          = "${var.business-unit}"
-    application            = "${var.application}"
-    is-production          = "${var.is-production}"
-    environment-name       = "${var.environment-name}"
-    owner                  = "${var.team_name}"
-    infrastructure-support = "${var.infrastructure-support}"
+  tags = {
+    business-unit          = var.business-unit
+    application            = var.application
+    is-production          = var.is-production
+    environment-name       = var.environment-name
+    owner                  = var.team_name
+    infrastructure-support = var.infrastructure-support
   }
 }
 
 module "dynamodb_autoscaler" {
   source = "git::https://github.com/ministryofjustice/cloud-platform-terraform-dynamodb-autoscaler.git?ref=tags/0.2.5-cp"
 
-  enabled                      = "${var.enable_autoscaler}"
+  enabled                      = var.enable_autoscaler
   name                         = "cp-dynamo-${random_id.id.hex}"
-  dynamodb_table_name          = "${aws_dynamodb_table.default.id}"
-  dynamodb_table_arn           = "${aws_dynamodb_table.default.arn}"
-  autoscale_write_target       = "${var.autoscale_write_target}"
-  autoscale_read_target        = "${var.autoscale_read_target}"
-  autoscale_min_read_capacity  = "${var.autoscale_min_read_capacity}"
-  autoscale_max_read_capacity  = "${var.autoscale_max_read_capacity}"
-  autoscale_min_write_capacity = "${var.autoscale_min_write_capacity}"
-  autoscale_max_write_capacity = "${var.autoscale_max_write_capacity}"
-  aws_region                   = "${var.aws_region}"
+  dynamodb_table_name          = aws_dynamodb_table.default.id
+  dynamodb_table_arn           = aws_dynamodb_table.default.arn
+  autoscale_write_target       = var.autoscale_write_target
+  autoscale_read_target        = var.autoscale_read_target
+  autoscale_min_read_capacity  = var.autoscale_min_read_capacity
+  autoscale_max_read_capacity  = var.autoscale_max_read_capacity
+  autoscale_min_write_capacity = var.autoscale_min_write_capacity
+  autoscale_max_write_capacity = var.autoscale_max_write_capacity
+  aws_region                   = var.aws_region
 }
 
 resource "aws_iam_user" "user" {
@@ -77,13 +83,13 @@ resource "aws_iam_user" "user" {
 }
 
 resource "aws_iam_access_key" "key" {
-  user = "${aws_iam_user.user.name}"
+  user = aws_iam_user.user.name
 }
 
 resource "aws_iam_user_policy" "userpol" {
-  name   = "${aws_iam_user.user.name}"
-  policy = "${data.aws_iam_policy_document.policy.json}"
-  user   = "${aws_iam_user.user.name}"
+  name   = aws_iam_user.user.name
+  policy = data.aws_iam_policy_document.policy.json
+  user   = aws_iam_user.user.name
 }
 
 data "aws_iam_policy_document" "policy" {
@@ -93,7 +99,8 @@ data "aws_iam_policy_document" "policy" {
     ]
 
     resources = [
-      "${aws_dynamodb_table.default.arn}",
+      aws_dynamodb_table.default.arn,
     ]
   }
 }
+

--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,7 @@ resource "aws_dynamodb_table" "default" {
 }
 
 module "dynamodb_autoscaler" {
-  source = "git::https://github.com/ministryofjustice/cloud-platform-terraform-dynamodb-autoscaler.git?ref=tags/0.2.5-cp"
+  source = "git::https://github.com/ministryofjustice/cloud-platform-terraform-dynamodb-autoscaler.git?ref=tags/0.2.6-cp"
 
   enabled                      = var.enable_autoscaler
   name                         = "cp-dynamo-${random_id.id.hex}"

--- a/output.tf
+++ b/output.tf
@@ -1,19 +1,20 @@
 output "table_name" {
-  value       = "${aws_dynamodb_table.default.name}"
+  value       = aws_dynamodb_table.default.name
   description = "DynamoDB table name"
 }
 
 output "table_arn" {
-  value       = "${aws_dynamodb_table.default.arn}"
+  value       = aws_dynamodb_table.default.arn
   description = "DynamoDB table ARN"
 }
 
 output "access_key_id" {
   description = "Access key id for db"
-  value       = "${aws_iam_access_key.key.id}"
+  value       = aws_iam_access_key.key.id
 }
 
 output "secret_access_key" {
   description = "Secret key for db"
-  value       = "${aws_iam_access_key.key.secret}"
+  value       = aws_iam_access_key.key.secret
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,11 @@
-variable "team_name" {}
+variable "team_name" {
+}
 
-variable "application" {}
+variable "application" {
+}
 
-variable "environment-name" {}
+variable "environment-name" {
+}
 
 variable "is-production" {
   default = "false"
@@ -17,26 +20,28 @@ variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form <team-name> (<team-email>)"
 }
 
-variable "hash_key" {}
+variable "hash_key" {
+}
 
 variable "hash_key_type" {
   default = "S"
 }
 
-variable "range_key" {}
+variable "range_key" {
+}
 
 variable "range_key_type" {
   default = "S"
 }
 
 variable "enable_encryption" {
-  type        = "string"
+  type        = string
   default     = "true"
   description = "Enable DynamoDB server-side encryption"
 }
 
 variable "ttl_attribute" {
-  type        = "string"
+  type        = string
   default     = "Expires"
   description = "DynamoDB table TTL attribute"
 }
@@ -72,7 +77,7 @@ variable "autoscale_max_write_capacity" {
 }
 
 variable "enable_autoscaler" {
-  type        = "string"
+  type        = string
   default     = "true"
   description = "Flag to enable/disable DynamoDB autoscaling"
 }
@@ -81,3 +86,4 @@ variable "aws_region" {
   description = "Region into which the resource will be created"
   default     = "eu-west-2"
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
To upgrade the module do:
when in terraform0.11.14 version, do terraform 0.12checklist. See if everything looks fine
switch to terraform 0.12.13 using tfswitch
do terraform 0.12upgrade

example/*.tf wasnot upgraded and will be done when needed. Changes are in the branch tf12-example-upgrade