### PR TITLE
Update aws_iam_user path.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -99,7 +99,7 @@ module "dynamodb_autoscaler" {
 
 resource "aws_iam_user" "user" {
   name = "cp-dynamo-${random_id.id.hex}"
-  path = "/system/dynamo-user/${var.team_name}/"
+  path = "/system/dynamo-user/"
 }
 
 resource "aws_iam_access_key" "key" {


### PR DESCRIPTION
Removed using team_name in the path, as this is causing error

It must begin and end with / and contain only alphanumeric characters and/or / characters.