### PR TITLE
Add-'namespace'-tag-to-dynamodb-cluster

### DIFF
--- a/example/dynamodb.tf
+++ b/example/dynamodb.tf
@@ -14,6 +14,7 @@ module "example_team_dynamodb" {
   environment-name       = "development"
   infrastructure-support = "example-team@digtal.justice.gov.uk"
   aws_region             = "eu-west-2"
+  namespace              = var.namespace
 
   hash_key  = "example-hash"
   range_key = "example-range"

--- a/main.tf
+++ b/main.tf
@@ -78,6 +78,7 @@ resource "aws_dynamodb_table" "default" {
     environment-name       = var.environment-name
     owner                  = var.team_name
     infrastructure-support = var.infrastructure-support
+    namespace              = var.namespace
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,9 @@ variable "business-unit" {
   default     = "mojdigital"
 }
 
+variable "namespace" {
+}
+
 variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form <team-name> (<team-email>)"
 }


### PR DESCRIPTION
Why:
[Tag all AWS resources with namespace name#2348](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/2348)