### PR TITLE
Evaluate the repository with terraform0.13upgrade binary

### DIFF
--- a/example/versions.tf
+++ b/example/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    kubernetes = {
+      source = "hashicorp/kubernetes"
+    }
+  }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,4 +1,12 @@
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+    random = {
+      source = "hashicorp/random"
+    }
+  }
 }


### PR DESCRIPTION
In our vision to upgrade Terraform to 0.13, we will need to run this binary over any Terraform files in our repository.