### PR TITLE
Add `dynamodb:ListTables` action to IAM policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -101,6 +101,16 @@ data "aws_iam_policy_document" "policy" {
       aws_dynamodb_table.default.arn,
     ]
   }
+
+  statement {
+    actions = [
+      "dynamodb:ListTables",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
 }
 
 #######################


### PR DESCRIPTION
After a chat with Steve Williams, I'm raising this PR to allow the action `dynamodb:ListTables` on resources `"*"`.

We faced a problem as part of a spike we are doing in our team (LAA Crime Apply). I confirmed the permission is required (listing tables) because the library we are using (dynamoid, ruby) has lazy creation of tables on write, meaning it checks if the table exists when trying to write something to a table, and if it does not exist it tries to create it on the spot.

In order to check if the table exists, is why it does the ListTables action. Then it has some internal cache of existing tables once it retrieves them. There might be other operations that also requires the "dynamodb:ListTables" too.

I’m conscious this means any user of the module will be able to list (and so get the names) of all created tables in dynamodb, which may be seen as a privacy/security concern, but given the table names are randomly generated (they look like this, for instance: `cp-84ea5eec32bf6549`) there is not a lot of harm in knowing it.

Please let me know if this all looks good to you, happy to address any concerns or fix problems with the code.