### PR TITLE
Grant permissions to the table indexes too

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -99,6 +99,7 @@ data "aws_iam_policy_document" "policy" {
 
     resources = [
       aws_dynamodb_table.default.arn,
+      "${aws_dynamodb_table.default.arn}/index/*",
     ]
   }
 


### PR DESCRIPTION
As per:

https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/iam-policy-specific-table-indexes.html

Without having permission on the (secondary) indexes, there is no possibility to use them as as soon as you try you are faced with:

```Aws::DynamoDB::Errors::AccessDeniedException (User: arn:aws:iam::12345678:user/system/dynamo-user/cp-dynamo-72eadeec89fb6444 is not authorized to perform: dynamodb:Query on resource: arn:aws:dynamodb:eu-west-2:12345678:table/cp-72eadeec89fb6444/index/StatusSubmittedAtIndex because no identity-based policy allows the dynamodb:Query action)```