### PR TITLE
Add Dependabot, unit test workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,6 +1,7 @@
 name: Generate terraform docs
 on:
   - pull_request
+
 jobs:
   docs:
     runs-on: ubuntu-latest
@@ -9,7 +10,7 @@ jobs:
       with:
         ref: ${{ github.event.pull_request.head.ref }}
 
-    - name: Render terraform docs inside the README.md and push changes back to PR branch
+    - name: Render terraform docs and push changes back to PR
       uses: terraform-docs/gh-actions@v1.0.0
       with:
         working-dir: .

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -1,0 +1,23 @@
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+jobs:
+  go-tests:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 0.14.x
+          terraform_wrapper: false
+
+      - name: Run terraform Tests
+        working-directory: example/
+        run: |
+          terraform init
+          terraform validate

--- a/example/dynamodb.tf
+++ b/example/dynamodb.tf
@@ -5,7 +5,7 @@
  *
  */
 module "example_team_dynamodb" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-dynamodb-cluster?ref=3.2.4"
+  source = "../"
 
   team_name              = var.team_name
   business-unit          = var.business_unit

--- a/example/dynamodb.tf
+++ b/example/dynamodb.tf
@@ -11,7 +11,7 @@ module "example_team_dynamodb" {
   business-unit          = var.business_unit
   application            = var.application
   is-production          = var.is_production
-  environment-name       = var.environment
+  environment-name       = var.environment_name
   infrastructure-support = var.infrastructure_support
   aws_region             = "eu-west-2"
   namespace              = var.namespace

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,10 +1,3 @@
-terraform {
-  backend "s3" {
-
-  }
-}
-
 provider "aws" {
   region = "eu-west-2"
 }
-

--- a/example/variables.tf
+++ b/example/variables.tf
@@ -1,0 +1,42 @@
+variable "application" {
+  description = "Name of Application you are deploying"
+  default     = "example-app"
+}
+
+variable "namespace" {
+  default = "example-team"
+}
+
+variable "business_unit" {
+  description = "Area of the MOJ responsible for the service."
+  default     = "Example"
+}
+
+variable "team_name" {
+  description = "The name of your development team"
+  default     = "example"
+}
+
+variable "environment_name" {
+  description = "The type of environment you're deploying to."
+  default     = "development"
+}
+
+variable "infrastructure_support" {
+  description = "The team responsible for managing the infrastructure. Should be of the form team-email."
+  default     = "example@digital.justice.gov.uk"
+}
+
+variable "is_production" {
+  default = "false"
+}
+
+variable "slack_channel" {
+  description = "Team slack channel to use if we need to contact your team"
+  default     = "example"
+}
+
+variable "github_owner" {
+  description = "Required by the github terraform provider"
+  default     = "ministryofjustice"
+}


### PR DESCRIPTION
This PR brings the `.github` directory up to date with [cloud-platform-terraform-template](https://github.com/ministryofjustice/cloud-platform-terraform-template), including adding Dependabot and workflows for unit tests and documentation.