### PR TITLE
feat: bump cloudposse/dynamodb-autoscaler to 0.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ See the [examples/](examples/) folder for more information.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_dynamodb_autoscaler"></a> [dynamodb\_autoscaler](#module\_dynamodb\_autoscaler) | cloudposse/dynamodb-autoscaler/aws | 0.14.0 |
+| <a name="module_dynamodb_autoscaler"></a> [dynamodb\_autoscaler](#module\_dynamodb\_autoscaler) | cloudposse/dynamodb-autoscaler/aws | 0.16.0 |
 
 ## Resources
 

--- a/main.tf
+++ b/main.tf
@@ -202,7 +202,7 @@ resource "aws_iam_role_policy" "autoscaler_cloudwatch" {
 module "dynamodb_autoscaler" {
   source = "cloudposse/dynamodb-autoscaler/aws"
 
-  version                      = "0.14.0"
+  version                      = "0.16.0"
   enabled                      = var.enable_autoscaler
   name                         = "cp-dynamo-${random_id.id.hex}"
   dynamodb_table_name          = aws_dynamodb_table.default.id


### PR DESCRIPTION
## Purpose

- See https://github.com/cloudposse/terraform-aws-dynamodb-autoscaler/releases
- It's mostly tagging related fixes which will help us with https://github.com/ministryofjustice/cloud-platform/issues/6963
- Tested using `mikebell-test` dynamodb and can see changes to tagging only. TF Output - https://concourse.cloud-platform.service.justice.gov.uk/builds/35523033